### PR TITLE
Add more unique publish markets stats

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -22,6 +22,23 @@ export function getYearAndWeek(timestamp: number) {
   const key = tdt.getFullYear() + '-' + week
   return key
 }
+
+export function getYearAndMonth(timestamp: number) {
+  const dt = new Date(timestamp * 1000)
+  const year = dt.getFullYear()
+  const month = dt.getMonth() + 1
+  const monthStr = month < 10 ? '0' + month : month.toString()
+  const key = `${year}-${monthStr}`
+  return key
+}
+
+export function getYear(timestamp: number) {
+  const dt = new Date(timestamp * 1000)
+  const year = dt.getFullYear()
+  const key = `${year}`
+  return key
+}
+
 export function getWeeksOfYear(from: number, to: number) {
   // returns all weeks from to
   const keys = []
@@ -31,5 +48,44 @@ export function getWeeksOfYear(from: number, to: number) {
     keys.push(getYearAndWeek(current))
     current += 7 * 86400
   } while (current < to)
+  return keys
+}
+
+function addOneMonth(timestamp) {
+  const date = new Date(timestamp * 1000)
+  date.setMonth(date.getMonth() + 1)
+  return Math.floor(date.getTime() / 1000)
+}
+
+export function getMontsOfYear(from: number, to: number) {
+  // returns all months from to
+  const keys = []
+
+  let current = from
+  do {
+    keys.push(getYearAndMonth(current))
+    current = addOneMonth(current)
+  } while (current < to)
+  return keys
+}
+
+function addOneYear(timestamp) {
+  const date = new Date(timestamp * 1000)
+  date.setFullYear(date.getFullYear() + 1)
+  return Math.floor(date.getTime() / 1000)
+}
+
+export function getYears(from: number, to: number) {
+  // returns all months from to
+  const keys = []
+  let current = from
+  let currentDate = new Date(from * 1000)
+  const endDate = new Date(to * 1000)
+
+  do {
+    keys.push(getYear(current))
+    current = addOneYear(current)
+    currentDate = new Date(current * 1000)
+  } while (currentDate.getFullYear() <= endDate.getFullYear())
   return keys
 }

--- a/src/routes/core.ts
+++ b/src/routes/core.ts
@@ -6,10 +6,13 @@ const cache = cacheService.cache
 import {
   getNoOfErc721,
   getUniqueConsumers,
-  getUniquePublishMarkets,
+  getWeeklyUniquePublishMarkets,
+  getMontlyUniquePublishMarkets,
   getFreeOrders,
   getOceanOrders,
-  getUniqueConsumeMarkets
+  getUniqueConsumeMarkets,
+  getYearlyUniquePublishMarkets,
+  getUniquePublishMarketsNumber
 } from '../controllers/core'
 
 const router = express.Router()
@@ -44,8 +47,9 @@ router.get(
     res.status(200).json(deposits)
   }
 )
+
 router.get(
-  '/uniquePublishMarkets',
+  '/weeklyUniquePublishMarkets',
   cache('10 minutes'),
   async function (req: Request, res: Response) {
     const { since, to } = req.query
@@ -55,7 +59,57 @@ router.get(
     else from = parseInt(since as string)
     if (!to) limit = now
     else limit = parseInt(to as string)
-    const deposits = await getUniquePublishMarkets(from, limit)
+    const weeklyPublishedMarkets = await getWeeklyUniquePublishMarkets(
+      from,
+      limit
+    )
+    res.status(200).json(weeklyPublishedMarkets)
+  }
+)
+
+router.get(
+  '/montlyUniquePublishMarkets',
+  cache('10 minutes'),
+  async function (req: Request, res: Response) {
+    const { since, to } = req.query
+    let from, limit
+    const now = Math.floor(Date.now() / 1000)
+    if (!since) from = now - 15780000 // 6 months
+    else from = parseInt(since as string)
+    if (!to) limit = now
+    else limit = parseInt(to as string)
+    const montlyPublishedMarkets = await getMontlyUniquePublishMarkets(
+      from,
+      limit
+    )
+    res.status(200).json(montlyPublishedMarkets)
+  }
+)
+
+router.get(
+  '/yearlyUniquePublishMarkets',
+  cache('10 minutes'),
+  async function (req: Request, res: Response) {
+    const { since, to } = req.query
+    let from, limit
+    const now = Math.floor(Date.now() / 1000)
+    if (!since) from = 1640995200 // 01-01-2022
+    else from = parseInt(since as string)
+    if (!to) limit = now
+    else limit = parseInt(to as string)
+    const yearlyPublishedMarkets = await getYearlyUniquePublishMarkets(
+      from,
+      limit
+    )
+    res.status(200).json(yearlyPublishedMarkets)
+  }
+)
+
+router.get(
+  '/totalUniquePublishMarkets',
+  cache('10 minutes'),
+  async function (req: Request, res: Response) {
+    const deposits = await getUniquePublishMarketsNumber()
     res.status(200).json(deposits)
   }
 )

--- a/src/routes/veOceanRoutes.ts
+++ b/src/routes/veOceanRoutes.ts
@@ -14,7 +14,6 @@ const router = express.Router()
 /* GET Access role premissions. */
 router.get('/lockedAmount', async function (req: Request, res: Response) {
   const lockedAmount = await veGetLockedAmount()
-  console.log('lockedAmount:' + lockedAmount)
   res.status(200).send('' + lockedAmount)
 })
 router.get(

--- a/static/core.html
+++ b/static/core.html
@@ -24,10 +24,22 @@
 	
 	<div><br><br><br><br><br></div>
 	<div class="chart-container" style="position: relative; height:300; width:800">
-        <canvas id="uniquePublishMarkets"></canvas>
+        <canvas id="weeklyUniquePublishMarkets"></canvas>
     </div>
 
 	<div><br><br><br><br><br></div>
+	<div class="chart-container" style="position: relative; height:300; width:800">
+        <canvas id="montlyUniquePublishMarkets"></canvas>
+    </div>
+
+	<div><br><br><br><br><br></div>
+	<div class="chart-container" style="position: relative; height:300; width:800">
+        <canvas id="yearlyUniquePublishMarkets"></canvas>
+    </div>
+
+	<div><br><br><br><br><br></div>
+    <div style="margin-top: 20px;margin-bottom: 20px;margin-left: 297px;font-family: sans-serif;font-size: 13px;font-weight: bold;" id="uniquePublishMarkets"></div>
+
 	<div class="chart-container" style="position: relative; height:300; width:800">
         <canvas id="uniqueConsumeMarkets"></canvas>
     </div>
@@ -45,6 +57,9 @@
 
 		getPublishedNfts();
 		getUniqueConsumers();
+		getWeeklyUniquePublishMarkets();
+		getMontlyUniquePublishMarkets();
+		getYearlyUniquePublishMarkets();
 		getUniquePublishMarkets();
 		getUniqueConsumeMarkets();
 		getFreeConsumes();
@@ -75,6 +90,7 @@
 				options: {
 					legend: { display: false },
 					title: {
+						fontFamily: 'sans-serif',
 						display: true,
 						text: 'NFTS Published per week'
 					}
@@ -109,6 +125,7 @@
 				options: {
 					legend: { display: false },
 					title: {
+						fontFamily: 'sans-serif',
 						display: true,
 						text: 'Unique consumers per week'
 					}
@@ -117,10 +134,9 @@
 
 		}
 
-		async function getUniquePublishMarkets() {
-			const response = await fetch('/api/core/uniquePublishMarkets');
+		async function getWeeklyUniquePublishMarkets() {
+			const response = await fetch('/api/core/weeklyUniquePublishMarkets');
 			const data = await response.json();
-			
 			
 
 			labels = [];
@@ -129,13 +145,13 @@
                 labels.push(key)
                 values.push(value)
             }
-			new Chart(document.getElementById("uniquePublishMarkets"), {
+			new Chart(document.getElementById("weeklyUniquePublishMarkets"), {
 				type: 'bar',
 				data: {
 					labels: labels,
 					datasets: [
 						{
-							label: "uniquePublishMarkets",
+							label: "weeklyUniquePublishMarkets",
 							data: values
 						}
 					]
@@ -143,6 +159,7 @@
 				options: {
 					legend: { display: false },
 					title: {
+						fontFamily: 'sans-serif',
 						display: true,
 						text: 'Unique Publishing Markets per week'
 					}
@@ -150,6 +167,90 @@
 			});
 
 		}
+
+		async function getMontlyUniquePublishMarkets(){
+			const response = await fetch('/api/core/montlyUniquePublishMarkets');
+			const data = await response.json();
+
+
+			labels = [];
+			values = [];
+            for (const [key, value] of Object.entries(data)){
+                labels.push(key)
+                values.push(value)
+            }
+			new Chart(document.getElementById("montlyUniquePublishMarkets"), {
+				type: 'bar',
+				data: {
+					labels: labels,
+					datasets: [
+						{
+							label: "montlyUniquePublishMarkets",
+							data: values
+						}
+					]
+				},
+				options: {
+					legend: { display: false },
+					title: {
+						fontFamily: 'sans-serif',
+						display: true,
+						text: 'Unique Publishing Markets per month'
+					},
+					scales: {
+        				yAxes: [{
+            				ticks: {
+                				beginAtZero: true
+            			}}]
+    				}	
+				}
+			});
+
+		}
+
+		async function getYearlyUniquePublishMarkets(){
+			const response = await fetch('/api/core/yearlyUniquePublishMarkets');
+			const data = await response.json();
+
+			labels = [];
+			values = [];
+            for (const [key, value] of Object.entries(data)){
+                labels.push(key)
+                values.push(value)
+            }
+			new Chart(document.getElementById("yearlyUniquePublishMarkets"), {
+				type: 'bar',
+				data: {
+					labels: labels,
+					datasets: [
+						{
+							label: "yearlyUniquePublishMarkets",
+							data: values
+						}
+					]
+				},
+				options: {
+					legend: { display: false },
+					title: {
+						fontFamily: 'sans-serif',
+						display: true,
+						text: 'Unique Publishing Markets per year'
+					},
+					scales: {
+        				yAxes: [{
+            				ticks: {
+                				beginAtZero: true
+            			}}]
+    				}			
+				}
+			});
+		}
+
+		async function getUniquePublishMarkets() {
+            const response = await fetch('api/core/totalUniquePublishMarkets');
+            const data = await response.text();
+            document.getElementById("uniquePublishMarkets").innerHTML = 'Total Unique Publish Markets: '+data
+        }
 
 		async function getUniqueConsumeMarkets() {
 			const response = await fetch('/api/core/uniqueConsumeMarkets');
@@ -177,6 +278,7 @@
 				options: {
 					legend: { display: false },
 					title: {
+						fontFamily: 'sans-serif',
 						display: true,
 						text: 'Unique Consume Markets per week'
 					}
@@ -184,8 +286,6 @@
 			});
 
 		}
-
-
 
 		async function getFreeConsumes() {
 			const response = await fetch('/api/core/freeConsumes');
@@ -213,6 +313,7 @@
 				options: {
 					legend: { display: false },
 					title: {
+						fontFamily: 'sans-serif',
 						display: true,
 						text: 'Free Consumes per week'
 					}
@@ -249,6 +350,7 @@
 				options: {
 					legend: { display: false },
 					title: {
+						fontFamily: 'sans-serif',
 						display: true,
 						text: 'Ocean Consumes per week'
 					},


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- adds totalUniquePublishMarkets, yearlyUniquePublishMarkets, montlyUniquePublishMarkets
<img width="821" alt="Screenshot 2023-04-13 at 22 24 30" src="https://user-images.githubusercontent.com/13447142/231862365-d6170b56-caf1-4913-b5da-2f7788bdce0b.png">

